### PR TITLE
Use relative paths for URIs

### DIFF
--- a/lib/Model/Subject/AbstractList.php
+++ b/lib/Model/Subject/AbstractList.php
@@ -43,7 +43,7 @@ abstract class AbstractList implements \IteratorAggregate
         for ($i = $currentPage; $i < $pages; ++$i) {
             $filters['pagina'] = $i;
 
-            $response = $this->client->request('POST', '/'.$this->getType().'/lista', $filters);
+            $response = $this->client->request('POST', $this->getType().'/lista', $filters);
             $data = Json::decode((string) $response->getBody(), true);
 
             $pages = $data['numero_pagine'];
@@ -60,7 +60,7 @@ abstract class AbstractList implements \IteratorAggregate
      */
     public function bulkCreate(Subject ...$subjects): self
     {
-        $this->client->request('POST', '/'.$this->getType().'/importa', [
+        $this->client->request('POST', $this->getType().'/importa', [
             'lista_soggetti' => $subjects,
         ]);
 

--- a/lib/Model/Subject/Subject.php
+++ b/lib/Model/Subject/Subject.php
@@ -195,7 +195,7 @@ abstract class Subject implements \JsonSerializable
     public function create(ClientInterface $client): self
     {
         $this->client = $client;
-        $path = '/'.($this instanceof Supplier ? 'fornitori' : 'clienti').'/nuovo';
+        $path = ($this instanceof Supplier ? 'fornitori' : 'clienti').'/nuovo';
 
         $response = $this->client->request('POST', $path, $this);
 
@@ -222,7 +222,7 @@ abstract class Subject implements \JsonSerializable
             return $this;
         }
 
-        $path = '/'.($this instanceof Supplier ? 'fornitori' : 'clienti').'/modifica';
+        $path = ($this instanceof Supplier ? 'fornitori' : 'clienti').'/modifica';
         $this->client->request('POST', $path, $update);
 
         return $this;
@@ -237,7 +237,7 @@ abstract class Subject implements \JsonSerializable
      */
     public function delete(): self
     {
-        $path = '/'.($this instanceof Supplier ? 'fornitori' : 'clienti').'/elimina';
+        $path = ($this instanceof Supplier ? 'fornitori' : 'clienti').'/elimina';
         $this->client->request('POST', $path, [
             'id' => $this->id,
         ]);


### PR DESCRIPTION
Refs #3

This way the whole `base_uri` is used without stripping out `/v1` from `https://api.fattureincloud.it/v1`