### PR TITLE
Fixing path for `get`

### DIFF
--- a/lib/Model/Subject/Subject.php
+++ b/lib/Model/Subject/Subject.php
@@ -216,7 +216,7 @@ abstract class Subject implements \JsonSerializable
         $obj->client = $client;
 
         $type = $obj instanceof Supplier ? 'fornitori' : 'clienti';
-        $path = $type.'/nuovo';
+        $path = $type.'/lista';
 
         $response = $client->request('POST', $path, [
             'id' => $id,


### PR DESCRIPTION
Looks like there's a typo, probably due to copy/paste from other method when introducing `get`.