### PR TITLE
Add missing `id` to request data

### DIFF
--- a/lib/Model/Subject/Subject.php
+++ b/lib/Model/Subject/Subject.php
@@ -270,6 +270,7 @@ abstract class Subject implements \JsonSerializable
         if (0 === count($update)) {
             return $this;
         }
+        $update['id'] = $this->id;
 
         $path = ($this instanceof Supplier ? 'fornitori' : 'clienti').'/modifica';
         $this->client->request('POST', $path, $update);

--- a/lib/Model/Subject/Subject.php
+++ b/lib/Model/Subject/Subject.php
@@ -20,7 +20,7 @@ abstract class Subject implements \JsonSerializable
      *
      * @var string
      */
-    public $id;
+    private $id;
 
     /**
      * Subject name.
@@ -119,6 +119,9 @@ abstract class Subject implements \JsonSerializable
     public function __get($name)
     {
         switch ($name) {
+            case 'id':
+                return $this->id ? $this->id : null;
+
             case 'phone':
                 return $this->phone ?
                     PhoneNumberUtil::getInstance()->format($this->phone, PhoneNumberFormat::E164) :
@@ -140,6 +143,10 @@ abstract class Subject implements \JsonSerializable
     public function & __set($name, $value)
     {
         switch ($name) {
+            case 'id':
+                $value = $value ? $value : null;
+                break;
+
             case 'phone':
                 $value = $value ?
                     PhoneNumberUtil::getInstance()->parse($value, 'IT') :
@@ -309,7 +316,7 @@ abstract class Subject implements \JsonSerializable
         $this->originalData = $data;
         \ksort($this->originalData);
 
-        $this->id = $data['id'] ?? null;
+        $this->__set('id', $data['id'] ?? null);
         $this->name = $data['nome'] ?? null;
         $this->reference = $data['referente'] ?? null;
         $this->country = $data['paese'] ?? null;

--- a/lib/Model/Subject/Subject.php
+++ b/lib/Model/Subject/Subject.php
@@ -120,7 +120,7 @@ abstract class Subject implements \JsonSerializable
     {
         switch ($name) {
             case 'id':
-                return $this->id ? $this->id : null;
+                return $this->id;
 
             case 'phone':
                 return $this->phone ?
@@ -143,10 +143,6 @@ abstract class Subject implements \JsonSerializable
     public function & __set($name, $value)
     {
         switch ($name) {
-            case 'id':
-                $value = $value ? $value : null;
-                break;
-
             case 'phone':
                 $value = $value ?
                     PhoneNumberUtil::getInstance()->parse($value, 'IT') :
@@ -316,7 +312,7 @@ abstract class Subject implements \JsonSerializable
         $this->originalData = $data;
         \ksort($this->originalData);
 
-        $this->__set('id', $data['id'] ?? null);
+        $this->id = $data['id'] ?? null;
         $this->name = $data['nome'] ?? null;
         $this->reference = $data['referente'] ?? null;
         $this->country = $data['paese'] ?? null;


### PR DESCRIPTION
`id` is mandatory but gets removed from array_diff_assoc because it has the same value (of course) in `$fields` and in `$this->originalData`. Adding it directly from the instance. 

@alekitto please check