### PR TITLE
Prevent `Notice: Only variable references should be returned by reference`

### DIFF
--- a/lib/Model/Document/Document.php
+++ b/lib/Model/Document/Document.php
@@ -388,7 +388,9 @@ abstract class Document implements \JsonSerializable
         }
 
         $accessor = function & () use ($name, $value) {
-            return $this->$name = $value;
+            $this->$name = $value;
+
+            return $this->$name;
         };
         $return = & $accessor();
 

--- a/lib/Model/Document/PublicAdministration.php
+++ b/lib/Model/Document/PublicAdministration.php
@@ -182,7 +182,9 @@ final class PublicAdministration
         }
 
         $accessor = function & () use ($name, $value) {
-            return $this->$name = $value;
+            $this->$name = $value;
+
+            return $this->$name;
         };
         $return = & $accessor();
 

--- a/lib/Model/Subject/Subject.php
+++ b/lib/Model/Subject/Subject.php
@@ -157,7 +157,9 @@ abstract class Subject implements \JsonSerializable
         }
 
         $accessor = function & () use ($name, $value) {
-            return $this->$name = $value;
+            $this->$name = $value;
+
+            return $this->$name;
         };
         $return = & $accessor();
 


### PR DESCRIPTION
@alekitto please check, not really sure about this.