### PR TITLE
Add missing countryIso value when serializing for creation

### DIFF
--- a/lib/Model/Document/Document.php
+++ b/lib/Model/Document/Document.php
@@ -489,6 +489,7 @@ abstract class Document implements \JsonSerializable
             'id_fornitore' => $this instanceof SupplierOrder ? $this->subject->id : null,
             'nome' => $this->subject->name,
             'paese' => $this->subject->country,
+            'paese_iso' => $this->subject->countryIso,
             'lingua' => $this->language,
             'piva' => $this->subject->vatNumber,
             'cf' => $this->subject->fiscalCode,


### PR DESCRIPTION
This is needed to set the country passing only its iso code. At the moment it's not sent to the API.