### PR TITLE
Change description attribute back

### DIFF
--- a/lib/Model/Document/Good.php
+++ b/lib/Model/Document/Good.php
@@ -138,10 +138,12 @@ final class Good implements \JsonSerializable
     {
         return \array_filter([
             'id' => $this->id,
+            'codice' => $this->code,
             'cod' => $this->code,
             'nome' => $this->name,
             'um' => $this->mu,
             'quantita' => $this->qty,
+            'descrizione' => $this->description,
             'desc' => $this->description,
             'categoria' => $this->category,
             'prezzo_netto' => null !== $this->netPrice ? \sprintf('%.5f', $this->netPrice->getAmount() / 100.0) : null,

--- a/lib/Model/Document/Good.php
+++ b/lib/Model/Document/Good.php
@@ -142,7 +142,7 @@ final class Good implements \JsonSerializable
             'nome' => $this->name,
             'um' => $this->mu,
             'quantita' => $this->qty,
-            'descrizione' => $this->description,
+            'desc' => $this->description,
             'categoria' => $this->category,
             'prezzo_netto' => null !== $this->netPrice ? \sprintf('%.5f', $this->netPrice->getAmount() / 100.0) : null,
             'prezzo_lordo' => null !== $this->grossPrice ? \sprintf('%.5f', $this->grossPrice->getAmount() / 100.0) : null,


### PR DESCRIPTION
I am not sure why this has been changed back to `descrizione`, but the API requires the keyword `desc` here: https://api.fattureincloud.it/v1/documentation/dist/#!/Prodotti/ProdottoNuovoSingolo

It would also be a good idea to introduce composer versions, as I pulled this breaking update of this package without even notifying there was an update and just now realized that my application did not work correctly....