### PR TITLE
Add GH Workflow to run php-cs-fixer on PRs and PUSH to master

### DIFF
--- a/.github/workflows/php-cs-fixer-pr.yml
+++ b/.github/workflows/php-cs-fixer-pr.yml
@@ -1,9 +1,6 @@
-name: PHP CS Fixer Pull Request
+name: PHP CS Fixer PR
 
 on:
-  push:
-    branches-ignore:
-      - 'master'
   pull_request:
     paths:
       - '**.php'
@@ -15,12 +12,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - uses: php-actions/composer@v2
 
       - name: Run php-cs-fixer
-        run: ./vendor/bin/php-cs-fixer fix
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Apply php-cs-fixer changes
+        run: ./vendor/bin/php-cs-fixer fix --dry-run

--- a/.github/workflows/php-cs-fixer-pr.yml
+++ b/.github/workflows/php-cs-fixer-pr.yml
@@ -1,0 +1,26 @@
+name: PHP CS Fixer Pull Request
+
+on:
+  push:
+    branches-ignore:
+      - 'master'
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  php-cs-fixer-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: php-actions/composer@v2
+
+      - name: Run php-cs-fixer
+        run: ./vendor/bin/php-cs-fixer fix
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply php-cs-fixer changes

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Install
-        run: composer install
+      - uses: php-actions/composer@v2
 
       - name: Run php-cs-fixer
         run: ./vendor/bin/php-cs-fixer fix

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,27 @@
+name: PHP CS Fixer
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Install
+        run: composer install
+
+      - name: Run php-cs-fixer
+        run: ./vendor/bin/php-cs-fixer fix
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply php-cs-fixer changes

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
     paths:
       - '**.php'
 
@@ -13,14 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
 
       - uses: php-actions/composer@v2
 
       - name: Run php-cs-fixer
-        run: ./vendor/bin/php-cs-fixer fix
-
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Apply php-cs-fixer changes
+        run: ./vendor/bin/php-cs-fixer fix --dry-run


### PR DESCRIPTION
Refs #19 

@alekitto this should cover the case of running `php-cs-fixer` on pull requests and direct pushed to master. Runs it using the `.php_cs.dist` and auto commits changes (if any) to the branch where it is running.