### PR TITLE
Drop not supported PHP versions

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'none'],
         'blank_line_after_opening_tag' => false,
+        'linebreak_after_opening_tag' => false,
         'lowercase_cast' => true,
         'lowercase_constants' => true,
         'lowercase_keywords' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.3
   - 7.4
   - 8.0
 
@@ -16,7 +15,7 @@ before_install: composer self-update
 
 install: composer update --prefer-dist --no-progress
 
-script: if [ "$TRAVIS_PHP_VERSION" == "7.1" ]; then vendor/bin/phpunit --coverage-clover=coverage.clover; else vendor/bin/phpunit; fi
+script: if [ "$TRAVIS_PHP_VERSION" == "7.4" ]; then vendor/bin/phpunit --coverage-clover=coverage.clover; else vendor/bin/phpunit; fi
 
 after_success:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP SDK for FattureinCloud.it APIs",
     "type": "library",
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-json": "*",
         "giggsey/libphonenumber-for-php": "^8.10",
         "php-http/discovery": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP SDK for FattureinCloud.it APIs",
     "type": "library",
     "require": {
-        "php": "^7.1",
+        "php": ">=7.3",
         "ext-json": "*",
         "giggsey/libphonenumber-for-php": "^8.10",
         "php-http/discovery": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "friendsofphp/php-cs-fixer": "^2.14",
         "monolog/monolog": "^1.24",
         "php-http/guzzle6-adapter": "^2.0",
-        "phpunit/phpunit": "^7.5",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.0",
         "symfony/cache": "^4.1|^5.0"
     },
     "license": "MIT",

--- a/tests/API/PurchaseTest.php
+++ b/tests/API/PurchaseTest.php
@@ -6,6 +6,7 @@ namespace Fazland\FattureInCloud\Tests\API;
 
 use Fazland\FattureInCloud\API\Purchase;
 use Fazland\FattureInCloud\Client\ClientInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use function GuzzleHttp\Psr7\stream_for;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -13,6 +14,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class PurchaseTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy|ClientInterface
      */

--- a/tests/API/PurchaseTest.php
+++ b/tests/API/PurchaseTest.php
@@ -6,9 +6,9 @@ namespace Fazland\FattureInCloud\Tests\API;
 
 use Fazland\FattureInCloud\API\Purchase;
 use Fazland\FattureInCloud\Client\ClientInterface;
-use Prophecy\PhpUnit\ProphecyTrait;
 use function GuzzleHttp\Psr7\stream_for;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/API/SubjectTest.php
+++ b/tests/API/SubjectTest.php
@@ -4,6 +4,7 @@ namespace Fazland\FattureInCloud\Tests\API;
 
 use Fazland\FattureInCloud\API\Subject;
 use Fazland\FattureInCloud\Client\ClientInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use function GuzzleHttp\Psr7\stream_for;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -11,6 +12,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class SubjectTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy|ClientInterface
      */

--- a/tests/API/SubjectTest.php
+++ b/tests/API/SubjectTest.php
@@ -4,9 +4,9 @@ namespace Fazland\FattureInCloud\Tests\API;
 
 use Fazland\FattureInCloud\API\Subject;
 use Fazland\FattureInCloud\Client\ClientInterface;
-use Prophecy\PhpUnit\ProphecyTrait;
 use function GuzzleHttp\Psr7\stream_for;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -18,6 +18,7 @@ use Fazland\FattureInCloud\Exception\Request\UnauthorizedException;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -25,6 +26,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class ClientTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ClientInterface|ObjectProphecy
      */

--- a/tests/Util/Money/PreciseMoneyTest.php
+++ b/tests/Util/Money/PreciseMoneyTest.php
@@ -8,10 +8,13 @@ use Money\Currency;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 final class PreciseMoneyTest extends TestCase
 {
+    use ProphecyTrait;
+
     private const AMOUNT = 10;
     private const OTHER_AMOUNT = 5;
     private const CURRENCY = 'EUR';


### PR DESCRIPTION
Dropping 7.1 and 7.2. Updated PHPUnit and fixed deprecations.
This way the library can be used also on systems running PHP8.